### PR TITLE
Improved module player stop function to use SIGTERM instead of SIGKILL.

### DIFF
--- a/modplayer.c
+++ b/modplayer.c
@@ -191,7 +191,7 @@ PHP_FUNCTION(modplayer_stop)
     m_pid = MODPLAYER_G(pid);
 
     if (m_pid > 0) {
-        kill(m_pid, SIGKILL);
+        kill(m_pid, SIGTERM);
         MODPLAYER_G(pid) = 0;
 
         RETURN_TRUE;


### PR DESCRIPTION
The idea behind this PR is to use the SIGTERM signal code instead of SIGKILL to avoid zombie process in unresponsive environments.